### PR TITLE
Check diagram name against illegal chars before saving

### DIFF
--- a/diagram_storage.py
+++ b/diagram_storage.py
@@ -25,6 +25,9 @@ def load_diagram(name):
 
 # save a flow diagram in the controller's local file system
 def save_diagram(name, diagram):
+    illegal = set('*?/\\')
+    if any((c in illegal) for c in name):
+        return
     if not os.path.exists('diagrams'):
         os.makedirs('diagrams')
     file_name = 'diagrams/' + name + '.json'


### PR DESCRIPTION
There doesn't seem to be an established pattern to send a response back to flow-server, which would probably be desired on the front-end to handle.

Absent a more specific thought on how this should be done, I would propose a generic "error" message from the controller, which sends a specific errorcode/message for handling on the front-end. `save_diagram` would then send an error message to the client if the save didn't happen (should probably be able to check the result of the os write as well), saving the chore having to set up and tear down a specific handler when expecting a response from an action. This would create a looser UX: the user would "save" only to be told a moment later that the save did not occur, for some specific reason the controller would supply