### PR TITLE
ensure we stop processing program after handling stop_diagram message

### DIFF
--- a/flow/flow.py
+++ b/flow/flow.py
@@ -505,6 +505,15 @@ class Flow(object):
                         json.dumps({    'controller_path': c.path_on_server(),
                                         'recording': False,
                                         'recording_interval': self.recording_interval }))
+            #
+            # Stop recording if in progress.
+            # Remove the currently running diagram program.
+            # Remove the currently set user.
+            #
+            self.recording_interval = None
+            self.recording_location = None
+            self.diagram            = None
+            self.username           = None
 
             if self.recording_location != stop_location:
                 #
@@ -517,16 +526,6 @@ class Flow(object):
                                         'message': "This controller was no longer recording at that location, but the recording has been marked as stopped."
                                     })
                 return
-
-            #
-            # Stop recording if in progress.
-            # Remove the currently running diagram program.
-            # Remove the currently set user.
-            #
-            self.recording_interval = None
-            self.recording_location = None
-            self.diagram            = None
-            self.username           = None
 
             self.send_message(  type + '_response',
                                 {   'success': True,

--- a/flow/flow.py
+++ b/flow/flow.py
@@ -511,7 +511,6 @@ class Flow(object):
             # Remove the currently set user.
             #
             self.recording_interval = None
-            self.recording_location = None
             self.diagram            = None
             self.username           = None
 
@@ -526,6 +525,8 @@ class Flow(object):
                                         'message': "This controller was no longer recording at that location, but the recording has been marked as stopped."
                                     })
                 return
+
+            self.recording_location = None
 
             self.send_message(  type + '_response',
                                 {   'success': True,


### PR DESCRIPTION
If the user ran a program with no data storage block, we would continue to process the program (and affect the relay) after handling the stop_diagram message.  This was because the comparison checking if stop_location == recording_location failed (a unique case when we have no recorded data) and we bailed before setting self-diagram = none.  By leaving the diagram with the previous state (instead of none), we continued to process the program in the main while loop.  Move call to set diagram to none before exiting message handler to prevent this from happening.
[#160222226]