### PR TITLE
Add error handling around firebase connection

### DIFF
--- a/flow/flow.py
+++ b/flow/flow.py
@@ -1048,7 +1048,7 @@ class Flow(object):
                 post_succeeded = True
             except Exception as err:
                 logging.error("Session post error: %s" % (err))
-                c.sleep(0.1)
+                c.sleep(1)
 		
         auth = r.json()
         id_token = auth["idToken"]


### PR DESCRIPTION
Add try/catch error handling around Firebase connection.  Put connection attempt in while loop so we can retry the connection if we fail with an exception.
Note 1: I have not been able to reproduce this connection error state so all of my tests have been with successful connections or a forced error.
Note 2: We will stay in the this loop indefinitely if the connection fails repeatedly.  This doesn't hold anything up, as this function is designed to run indefinitely in a while loop sending sensor status updates to Firebase (so we're simply spinning in an earlier connection while loop prior to the send status loop).   An alternate method would be to have a maximum number of connection retries and then exit the function with an error message.  PIs, however, requested that we continue connection attempts.